### PR TITLE
add a contact delete method

### DIFF
--- a/lib/contact.ts
+++ b/lib/contact.ts
@@ -48,4 +48,11 @@ export default class Contact {
       url: `/api/REST/1.0/data/contact/${id}`
     });
   }
+
+  delete (id: number) {
+    return this.client._request({
+      method: 'DELETE',
+      url: `/api/REST/1.0/data/contact/${id}`
+    });
+  }
 }


### PR DESCRIPTION
I have added a call for this resource https://docs.oracle.com/en/cloud/saas/marketing/eloqua-rest-api/op-api-rest-1.0-data-contact-id-delete.html
I haven't added any tests because it looks like you run them agains the real server, so I'm not sure how to test a `delete` method call in this case.